### PR TITLE
Use `document.head` if it’s available and clean up the bookmarklet code + HTML and CSS

### DIFF
--- a/bookmarklet.html
+++ b/bookmarklet.html
@@ -3,9 +3,8 @@
 <head>
   <title>DOM Monster Bookmarklet</title>
   <meta http-equiv="imagetoolbar" content="no" />
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <style type="text/css" media="screen"></style>
-  <style type="text/css" media="screen">
+  <meta charset="utf-8" />
+  <style media="screen">
     body { 
       font:14px/18px 'Lucida Grande', Verdana, sans-serif;
       margin: 40px 0 25px 50px;
@@ -17,7 +16,7 @@
       margin:0;
       width:618px;
       height:174px;
-      text-indent:-999px;
+      text-indent:-9999em;
       background:url(assets/dom-monster.png);
     }
     p {
@@ -38,6 +37,7 @@
       padding: 5px;
       -webkit-border-radius: 5px;
       -moz-border-radius: 5px;
+      border-radius: 5px;
     }
     p.copyright {
       margin-top: 30px;
@@ -53,6 +53,8 @@
       border: 3px solid #f0f0f0;
       padding: 20px;
       width: 470px;
+      -webkit-border-radius: 20px;
+      -moz-border-radius: 20px;
       border-radius: 20px;
       text-align: center;
     }
@@ -61,17 +63,17 @@
 <body>
   <h2>Meet the DOM Monster!</h2>
   <p style="margin-top:-40px">
-    <b>DOM Monster</b> is our answer to JavaScript performance tools that just don't give you the full picture.
+    <b>DOM Monster</b> is our answer to JavaScript performance tools that just don’t give you the full picture.
   </p>
   <p>
-    <b>DOM Monster</b> is a cross-platform, cross-browser bookmarklet that will analyze the DOM &amp; other features of the page you're on, and give you its bill of health.
+    <b>DOM Monster</b> is a cross-platform, cross-browser bookmarklet that will analyze the DOM &amp; other features of the page you’re on, and give you its bill of health.
   </p>
   <p>
-    If there are problems, <b>DOM Monster</b> will point them out&#151;and even make suggestions on how to fix 'em.
+    If there are problems, <b>DOM Monster</b> will point them out — and even make suggestions on how to fix ’em.
   </p>
   
   <p class="important">
-    Drag the <a class="bookmarklet" href="javascript:(function(){var%20script=document.createElement('script');script.type='text/javascript';script.src='http://mir.aculo.us/dom-monster/dommonster.js?'+(new%20Date().getTime());document.getElementsByTagName('body')[0].appendChild(script);})()">DOM Monster!</a> to your bookmarks bar!
+    Drag the <a class="bookmarklet" href="javascript:(function(){var%20script=document.createElement('script');script.src='http://mir.aculo.us/dom-monster/dommonster.js?'+(%2Bnew%20Date()%3B);document.body.appendChild(script);})()">DOM Monster!</a> to your bookmarks bar!
   </p>
   
   <p>
@@ -88,7 +90,7 @@
   </p>
     
   <p class="learn-more">
-    <a href="http://javascriptrocks.com/performance/"><img src="assets/jsrocks.png"></a>
+    <a href="http://javascriptrocks.com/performance/"><img src="assets/jsrocks.png" alt="JavaScript Rocks!"></a>
     Learn more about the DOM Monster! and how to deal with DOM and JavaScript performance issues!
     Grab a copy of our<br> <a href="http://javascriptrocks.com/performance/">JavaScript Rocks! performance ebook</a>. 
   </p>

--- a/src/dommonster.js
+++ b/src/dommonster.js
@@ -106,9 +106,9 @@
    }
 
    if(count>2 && count<6)
-     JR.tip('Found '+count+' &lt;script&gt; tags on page.','Try to reduce the amount of script tags.');
+     JR.tip('Found '+count+' &lt;script&gt; tags on page.','Try to reduce the number of script tags.');
    if(nodes.length>=6)
-     JR.warn('Found '+count+' &lt;script&gt; tags on page.','Try to reduce the amount of script tags.');
+     JR.warn('Found '+count+' &lt;script&gt; tags on page.','Try to reduce the number of script tags.');
 
    if(headcount>0)
      JR.tip('<span style="cursor:help" title="'+sources.join('\n')+'">Found '+headcount+' &lt;script&gt; tags in HEAD.</span>','For better perceived loading performance move script tags to end of document.');
@@ -143,9 +143,9 @@
  JR.iFrameTips = function(){
    var nodes = document.getElementsByTagName('iframe');
    if(nodes.length>0 && nodes.length<4)
-     JR.tip('Reduce the amount of &lt;iframe&gt; tags.','There are '+nodes.length+' iframe elements on the page.');
+     JR.tip('Reduce the number of &lt;iframe&gt; tags.','There are '+nodes.length+' iframe elements on the page.');
    if(nodes.length>=4)
-     JR.warn('Reduce the amount of &lt;iframe&gt; tags','There are '+nodes.length+' iframe elements on the page.');
+     JR.warn('Reduce the number of &lt;iframe&gt; tags','There are '+nodes.length+' iframe elements on the page.');
  };
 
  JR.cssTips = function(){
@@ -154,15 +154,15 @@
    if(i==0) return;
    while(i--) if((links[i].rel||'').toLowerCase()=='stylesheet') nodes.push(links[i]);
    if(nodes.length>1 && nodes.length<8)
-     JR.tip('Reduce the amount of &lt;link rel="stylesheet"&gt; tags.','There are '+nodes.length+' external stylesheets loaded on the page.');
+     JR.tip('Reduce the number of &lt;link rel="stylesheet"&gt; tags.','There are '+nodes.length+' external stylesheets loaded on the page.');
    if(nodes.length>=8)
-     JR.warn('Reduce the amount of &lt;link rel="stylesheet"&gt; tags','There are '+nodes.length+' external stylesheets loaded on the page.');
+     JR.warn('Reduce the number of &lt;link rel="stylesheet"&gt; tags','There are '+nodes.length+' external stylesheets loaded on the page.');
    }
    function styleAttributeTips(){
      var nodes = document.getElementsByTagName('*'), i = nodes.length, styleNodes = 0;
      while(i--) if(nodes[i].style.cssText.length > 0) styleNodes++;
      if(styleNodes>0)
-       JR.tip('Reduce the amount of tags that use the style attribute, replacing it with external CSS definitions.','There are '+styleNodes+' nodes that use the style attribute.');
+       JR.tip('Reduce the number of tags that use the style attribute, replacing it with external CSS definitions.','There are '+styleNodes+' nodes that use the style attribute.');
    }
    linkTagTips();
    styleAttributeTips();
@@ -311,7 +311,7 @@
      JR.warn('Average DOM serialization speed is '+bodycount.toFixed(3)+'s.','Try to reduce the complexity of the DOM structure.');
 
    if(nodes.length>1500)
-     JR.warn('Element count seems excessively high.','Performance might improve if you reduce the amount of nodes.');
+     JR.warn('Element count seems excessively high.','Performance might improve if you reduce the number of nodes.');
    if(average>8 && average<=15)
      JR.tip('Nesting depth is a little high.','Reducing it might increase performance.');
    if(very)

--- a/src/dommonster.js
+++ b/src/dommonster.js
@@ -85,7 +85,7 @@
 
  JR.scriptTagsTips = function(){
    var nodes = document.getElementsByTagName('script'),
-     head = document.getElementsByTagName('head')[0];
+     head = document.head || document.getElementsByTagName('head')[0];
 
    var count = 0, headcount = 0, i = nodes.length, sources = [];
    while(i--){


### PR DESCRIPTION
Use `document.head` if it’s available. See http://mathiasbynens.be/notes/document-head for details.

Also, clean up the bookmarklet:
- Don’t set `script.type='text/javascript'` as it’s unnecessary;
- Use `document.body` instead of `document.getElementsByTagName('body')[0]`;
- Use `+new Date()` instead of `new Date.getTime()`.

Bonus: clean up the HTML and CSS a bit, and fix minor grammar mistakes.
