### PR TITLE
Adding external webfont detection

### DIFF
--- a/src/dommonster.js
+++ b/src/dommonster.js
@@ -164,6 +164,11 @@
     if(typeof Ext === 'object' && Ext.version < '3.3.1')
       JR.tip("You are using the Ext JS v"+Ext.version+".","There's a newer version available, which potentially includes performance updates.");
   };
+
+	JR.webfontTips = function(){
+		if(typeof Typekit == 'object')
+			JR.warn("You are using the Typekit webfont service.","Using external webfont services can increase your page load times, as well as possible downtime if the service goes down.");
+	}
   
   JR.iFrameTips = function(){
     var nodes = document.getElementsByTagName('iframe');
@@ -449,6 +454,7 @@
   
     JR.doctypeTips();
     JR.frameworkTips();
+		JR.webfontTips();
     JR.scriptTagsTips();
     JR.iFrameTips();
     JR.cssTips();

--- a/src/dommonster.js
+++ b/src/dommonster.js
@@ -166,10 +166,39 @@
   };
 
 	JR.webfontTips = function(){
-		if(typeof Typekit == 'object')
+		if(typeof Typekit == 'object'){
 			JR.warn("You are using the Typekit webfont service.","Using external webfont services can increase your page load times, as well as possible downtime if the service goes down.");
-	}
-  
+			return "";
+		}
+		
+		function isFontService(href){
+		if(href.indexOf("webtype.com") != -1 || href.indexOf("fontdeck.com") != -1 || href.indexOf("fontslive.com") != -1 ||
+		 		 href.indexOf("fonts.com") != -1 || href.indexOf("fonts.googleapis.com") || href.indexOf("kernest.com") ||
+				 href.indexOf("typotheque.com") != -1)
+			return true;
+		else
+			return false;
+		}
+		var styles = document.styleSheets, i = styles.length;
+		if(i==0) return;
+    while(i--) {
+			var href = styles[i].href||'', j = 0;
+			if(styles[i].rules) j = styles[i].rules.length;
+			if(isFontService(href)){
+			  JR.warn("You are using an external webfont service.","Using external webfont services can increase your page load times, as well as possible downtime if the service goes down.");
+				return "";
+			}
+			if(j==0) continue;
+			while(j--){
+				var href = styles[i].rules[j].href||'';
+				if(isFontService(href)){
+			  	JR.warn("You are using an external webfont service.","Using external webfont services can increase your page load times, as well as possible downtime if the service goes down.");
+					return "";
+				}
+			}
+		}
+  };
+
   JR.iFrameTips = function(){
     var nodes = document.getElementsByTagName('iframe');
     if(nodes.length>0 && nodes.length<4)


### PR DESCRIPTION
Typekit launches itself through the 'Typekit' object. I simply check if a Typekit object exists and display a warning if it does.
