### PR TITLE
Move JR.cssTips() to start of JR.performanceTips so cssTips does not pick up inline styles from later tips. Closes #27

### DIFF
--- a/src/dommonster.js
+++ b/src/dommonster.js
@@ -542,6 +542,8 @@
   };
 
   JR.performanceTips = function(){
+    JR.cssTips();
+
     function level(value,mid,high){
       return value<mid?'low':value<high?'mid':'high';
     }
@@ -592,7 +594,6 @@
     JR.webfontTips();
     JR.scriptTagsTips();
     JR.iFrameTips();
-    JR.cssTips();
     JR.opacityTips();
     JR.flashTips();
     JR.globals();


### PR DESCRIPTION
Closes #27: Nesting depth rule conflicts with inline style rule.

This seems to work better now.

(This is my first pull request on GitHub, so go easy!)
