### PR TITLE
adjust bookmarklet script src to support http or https

### DIFF
--- a/bookmarklet.html
+++ b/bookmarklet.html
@@ -73,7 +73,7 @@
   </p>
 
   <p class="important">
-    Drag the <a class="bookmarklet" href="javascript:(function(){var%20script=document.createElement('script');script.src='http://mir.aculo.us/dom-monster/dommonster.js?'+Math.floor((+new Date)/(864e5));document.body.appendChild(script);})()">DOM Monster!</a> to your bookmarks bar!
+    Drag the <a class="bookmarklet" href="javascript:(function(){var%20script=document.createElement('script');script.src='//mir.aculo.us/dom-monster/dommonster.js?'+Math.floor((+new Date)/(864e5));document.body.appendChild(script);})()">DOM Monster!</a> to your bookmarks bar!
   </p>
 
   <p>


### PR DESCRIPTION
Removed the http: from the script src in the bookmarklet to add support for https sites. Fixes #63
