### PR TITLE
Fix for JR.globals allowed list

### DIFF
--- a/src/dommonster.js
+++ b/src/dommonster.js
@@ -644,7 +644,7 @@
 
   JR.globals = function(){
     function ignore(name){
-      var allowed = ['Components','XPCNativeWrapper','XPCSafeJSObjectWrapper','getInterface','netscape','GetWeakReference'],
+      var allowed = ['Components','XPCNativeWrapper','XPCSafeJSObjectWrapper','getInterface','netscape','GetWeakReference','printStackTrace','__DOMMonsterJdropCallBack'],
       i = allowed.length;
       while(i--){
         if(allowed[i] === name)


### PR DESCRIPTION
printStackTrace and __DOMMonsterJdropCallBack added to allowed global list because they are own methods of DOM Monster :)
